### PR TITLE
test: add native node:test unit tests + CI workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,9 @@ build
 # Never bake secrets into the image
 .env
 .env.*
+# Tests run in CI, not in the runtime image
+**/*.test.ts
+**/*.test.js
 # Compose / docs are not needed inside the image
 docker-compose.yml
 *.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    name: Build & test (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # 22 = production (Docker node:22); 24 = the next line, so a future
+        # base-image or Node bump is caught before it reaches prod.
+        node-version: ['22', '24']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check & build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+
+      - name: Check formatting
+        run: npm run format:check

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
   "scripts": {
     "start": "node --env-file-if-exists=.env ./build/bot.js",
     "build": "tsc",
-    "prettify": "prettier --write ."
+    "pretest": "tsc",
+    "test": "node --test \"build/**/*.test.js\"",
+    "prettify": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "repository": {
     "type": "git",

--- a/src/common/xenforoWrapper.test.ts
+++ b/src/common/xenforoWrapper.test.ts
@@ -1,0 +1,141 @@
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+// xenforoWrapper reads XF_URL / XF_API_KEY once, at module-load time, so we must
+// set them BEFORE importing it. A dynamic import runs after these assignments
+// (unlike a hoisted static import), so the module picks up these test values.
+process.env.XF_URL = 'https://forum.test';
+process.env.XF_API_KEY = 'test-api-key';
+
+const { default: xenforo } = await import('./xenforoWrapper.js');
+
+interface FetchCall {
+  url: string;
+  init: any;
+}
+
+const realFetch = globalThis.fetch;
+
+// Replace the global fetch with a stub that records the call and returns a
+// native Response built from `body`/`status`. The wrapper uses the global fetch
+// and native Response, so this stub exercises exactly the surface a Node/undici
+// upgrade could change.
+function stubFetch(body: string, status = 200): FetchCall[] {
+  const calls: FetchCall[] = [];
+  globalThis.fetch = (async (url: any, init: any) => {
+    calls.push({ url: String(url), init });
+    return new Response(body, { status });
+  }) as typeof fetch;
+  return calls;
+}
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+// Invoke one wrapper method and resolve with the (error, response, body) it
+// hands to its node-style callback.
+function call(method: (args: any, extra: any, cb: any) => any, args: any): Promise<{ err: any; res: any; body: any }> {
+  return new Promise((resolve) => {
+    method(args, '', (err: any, res: any, body: any) => resolve({ err, res, body }));
+  });
+}
+
+test('getForum builds the forum-threads URL, sends the API key, and parses JSON', async () => {
+  const calls = stubFetch('{"threads":[{"thread_id":1}]}');
+  const { err, res, body } = await call(xenforo.getForum, { id: 5 });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, 'https://forum.test/api/forums/5/threads/');
+  assert.equal(calls[0].init.method, 'GET');
+  assert.equal(calls[0].init.headers['XF-Api-Key'], 'test-api-key');
+  assert.equal(err, null);
+  assert.deepEqual(body, { threads: [{ thread_id: 1 }] });
+  assert.ok(res, 'the raw Response is passed through to the callback');
+});
+
+test('GET endpoints build the documented API paths', async () => {
+  const cases: [(args: any, extra: any, cb: any) => any, any, string][] = [
+    [xenforo.getThreads, {}, 'threads/'],
+    [xenforo.getThread, { id: 10 }, 'threads/10/'],
+    [xenforo.getUser, { id: 3 }, 'users/3/'],
+    [xenforo.getMessage, { id: 8 }, 'posts/8/'],
+    [xenforo.getForum, { id: 2 }, 'forums/2/threads/'],
+  ];
+  for (const [fn, args, path] of cases) {
+    const calls = stubFetch('{}');
+    await call(fn, args);
+    assert.equal(calls[0].url, 'https://forum.test/api/' + path);
+    assert.equal(calls[0].init.method, 'GET');
+  }
+});
+
+test('path segments are URL-encoded so they stay a single safe segment', async () => {
+  const calls = stubFetch('{}');
+  await call(xenforo.getUser, { id: 'a b/c' });
+  assert.equal(calls[0].url, 'https://forum.test/api/users/a%20b%2Fc/');
+});
+
+test('postMessage sends an x-www-form-urlencoded body with raw (un-pre-encoded) values', async () => {
+  const calls = stubFetch('{"message":"ok"}');
+  await call(xenforo.postMessage, { thread_id: 3, message: 'Hello world & <b>tags</b>' });
+
+  assert.equal(calls[0].url, 'https://forum.test/api/posts/');
+  assert.equal(calls[0].init.method, 'POST');
+  assert.ok(calls[0].init.body instanceof URLSearchParams, 'body is a URLSearchParams');
+  assert.equal(calls[0].init.body.get('thread_id'), '3');
+  assert.equal(calls[0].init.body.get('message'), 'Hello world & <b>tags</b>');
+  // URLSearchParams applies the on-the-wire encoding (spaces -> +, & -> %26, etc.):
+  assert.equal(calls[0].init.body.toString(), 'thread_id=3&message=Hello+world+%26+%3Cb%3Etags%3C%2Fb%3E');
+});
+
+test('updateThread omits undefined fields from the body', async () => {
+  const calls = stubFetch('{}');
+  await call(xenforo.updateThread, { id: 7, prefix_id: 2, title: 'New title' });
+  assert.equal(calls[0].url, 'https://forum.test/api/threads/7/');
+  assert.equal(calls[0].init.body.toString(), 'prefix_id=2&title=New+title');
+});
+
+test('setThreadTag builds a custom_fields[...] parameter', async () => {
+  const calls = stubFetch('{}');
+  await call(xenforo.setThreadTag, { id: 4, tag_name: 'status', tag_value: 'approved' });
+  assert.equal(calls[0].init.body.toString(), 'custom_fields%5Bstatus%5D=approved');
+});
+
+test('a non-JSON response (e.g. a Cloudflare HTML challenge) is surfaced as an error', async () => {
+  stubFetch('<html>Attention Required</html>', 403);
+  const { err, res, body } = await call(xenforo.getForum, { id: 5 });
+  assert.ok(err instanceof Error);
+  assert.match(err.message, /non-JSON/);
+  assert.ok(res, 'the response is still passed for inspection');
+  assert.equal(body, null);
+});
+
+test('an empty response body yields (null error, response, null body)', async () => {
+  stubFetch('');
+  const { err, res, body } = await call(xenforo.getThread, { id: 1 });
+  assert.equal(err, null);
+  assert.ok(res);
+  assert.equal(body, null);
+});
+
+test('a network/fetch failure is passed to the callback as an error', async () => {
+  globalThis.fetch = (async () => {
+    throw new Error('network down');
+  }) as typeof fetch;
+  const { err, res, body } = await call(xenforo.getForum, { id: 5 });
+  assert.ok(err instanceof Error);
+  assert.equal(err.message, 'network down');
+  assert.equal(res, null);
+  assert.equal(body, null);
+});
+
+test('the callback may be passed as the second argument (2-arg call form)', async () => {
+  const calls = stubFetch('{"ok":true}');
+  const result = await new Promise<{ err: any; res: any; body: any }>((resolve) => {
+    (xenforo.getThreads as any)({}, (err: any, res: any, body: any) => resolve({ err, res, body }));
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(result.err, null);
+  assert.deepEqual(result.body, { ok: true });
+});

--- a/src/smoke.test.ts
+++ b/src/smoke.test.ts
@@ -1,0 +1,31 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// These guard the platform + dependency contracts the bot depends on. If a Node
+// upgrade removed the global fetch, changed how a URLSearchParams body is
+// encoded, or a mysql2 major renamed its entry points, these fail loudly — which
+// is the whole point of running them on every dependency bump in CI.
+
+test('the Node runtime provides the Web APIs the bot uses natively (Node >= 18)', () => {
+  assert.equal(typeof fetch, 'function', 'global fetch (undici) must exist — the bot dropped node-fetch');
+  assert.equal(typeof Response, 'function');
+  assert.equal(typeof Headers, 'function');
+  assert.equal(typeof URLSearchParams, 'function');
+});
+
+test('native fetch auto-sets the urlencoded Content-Type for a URLSearchParams body', () => {
+  // xenforoWrapper relies on this platform behaviour instead of setting the
+  // header itself. Build a Request the same way and assert it still holds.
+  const req = new Request('https://example.test/', {
+    method: 'POST',
+    body: new URLSearchParams({ a: 'b' }),
+  });
+  assert.match(req.headers.get('content-type') ?? '', /application\/x-www-form-urlencoded/);
+});
+
+test('mysql2/promise still exposes the connection API db.ts uses', async () => {
+  const mod: any = await import('mysql2/promise');
+  const mysql = mod.default ?? mod;
+  assert.equal(typeof mysql.createConnection, 'function', 'db.ts calls mysql.createConnection');
+  assert.equal(typeof mysql.createPool, 'function');
+});


### PR DESCRIPTION
Adds a dependency-update safety net that runs automatically on every push/PR, using Node's built-in test runner (`node:test`) — **no new dependencies** (in keeping with the recent dotenv/node-fetch removals).

## Tests
Written in TypeScript under `src/`, compiled by `tsc`, run with `node --test`.

**`xenforoWrapper.test.ts`** — mocks the global `fetch` and asserts:
- URL/path building for every GET endpoint + `encodeURIComponent` of path segments
- `XF-Api-Key` header and GET/POST method
- urlencoded request bodies (raw values, omitted `undefined` fields, `custom_fields[...]`)
- response handling: JSON parse, non-JSON → error (the Cloudflare-challenge case), empty body, `fetch` rejection, and the 2-arg callback form

**`smoke.test.ts`** — guards platform/dependency contracts so a Node or mysql2 bump fails loudly:
- native `fetch`/`Response`/`Headers`/`URLSearchParams` exist
- native fetch auto-sets the urlencoded `Content-Type` for a `URLSearchParams` body (the behavior the wrapper depends on)
- `mysql2/promise` still exposes `createConnection`/`createPool`

## Tooling
- `package.json`: `test` (`node --test`), `pretest` (`tsc`), `format:check`
- `.dockerignore`: exclude `**/*.test.{ts,js}` so tests never enter the runtime image (verified — image `build/` has only `bot.js` + `common/*`)
- `.github/workflows/ci.yml`: build + test + format check on **Node 22 and 24**

All 13 tests pass locally; `prettier --check .` clean. This PR itself exercises the new CI.